### PR TITLE
Make recovery permissive

### DIFF
--- a/recovery.te
+++ b/recovery.te
@@ -7,6 +7,7 @@ type recovery, domain;
 # But the allow rules are only included in the recovery policy.
 # Otherwise recovery is only allowed the domain rules.
 recovery_only(`
+  permissive recovery;
   allow recovery self:capability { chown dac_override fowner fsetid setfcap setuid setgid sys_admin sys_tty_config };
 
   # Set security contexts on files that are not known to the loaded policy.


### PR DESCRIPTION
A lot of devices are including TWRP to be built alongside the ROM, but because the default setting for most kernels in AOSPA-L is to set SELinux to Enforcing, TWRP refuses to boot.

Originally proposed to CyanogenMod by Dees_Troy at http://review.cyanogenmod.org/#/c/91776/2
